### PR TITLE
Add mobile responsive styles

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -250,3 +250,34 @@
 #submit-button:active{
   background-color: black;
 }
+
+@media (max-width: 600px) {
+  .app {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+  }
+  .side-bar {
+    order: 1;
+    width: 100%;
+    border-left: none;
+    border-top: 1px solid #dcdcdc;
+  }
+  .body {
+    order: 2;
+  }
+  .header {
+    order: 0;
+  }
+  .side-bar-histories {
+    font-size: 4vw;
+  }
+  .user-prompt,
+  .ai-response {
+    max-width: 90vw;
+    font-size: 16px;
+  }
+  #footer-search-bar {
+    width: 90vw;
+  }
+}

--- a/client/src/home/home.module.css
+++ b/client/src/home/home.module.css
@@ -133,6 +133,13 @@
     padding: 0;
 }
 
+@media (max-width: 600px) {
+    .aiPresets,
+    .setNewAiErrorField {
+        width: 40vw;
+    }
+}
+
 @keyframes shake{
     0%, 100% { transform: translateX(0); }
     20%, 60% { transform: translateX(-8px); }

--- a/client/src/login/login.module.css
+++ b/client/src/login/login.module.css
@@ -2,7 +2,7 @@
 
 .mainContainer{
     height: 100vh;
-    width: 100vh;
+    width: 100vw;
     align-items: center;
     justify-content: center;
     padding: 4vh;
@@ -18,6 +18,13 @@
     height: 60vh;
     width: 45vh;
 
+}
+
+@media (max-width: 600px) {
+    .fieldsContainer{
+        width: 90vw;
+        height: auto;
+    }
 }
 
 .heading1 {

--- a/client/src/signup/signup.module.css
+++ b/client/src/signup/signup.module.css
@@ -2,7 +2,7 @@
 
 .mainContainer{
     height: 100vh;
-    width: 100vh;
+    width: 100vw;
     align-items: center;
     justify-content: center;
     padding: 4vh;
@@ -18,6 +18,13 @@
     height: 60vh;
     width: 45vh;
 
+}
+
+@media (max-width: 600px) {
+    .fieldsContainer{
+        width: 90vw;
+        height: auto;
+    }
 }
 
 .heading1 {


### PR DESCRIPTION
## Summary
- add responsive layout rules for chat interface
- tweak login and signup pages for small screens
- adjust AI preset list sizing for phone view

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm test` in server *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6867add05c8c8332a6574cbd1fa34e96